### PR TITLE
Fix package versions to be compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,16 @@
 # List of dependencies to install
-absl-py
-apache-beam
-flax
-GitPython  # for "git" module
-google-cloud-storage
-immutabledict
-javalang
-jax
-numpy
-requests
-tensorflow
-tqdm
-tensor2tensor
-unidiff
-nltk
+absl-py==0.12.0
+apache-beam==2.34.0
+flax==0.3.6
+GitPython==3.1.24
+google-cloud-storage==1.43.0
+immutabledict==2.2.1
+javalang==0.13.0
+jax==0.2.26
+nltk==3.6.6
+numpy==1.19.5
+requests==2.24.0
+tensorflow==2.5.0
+tensor2tensor==1.15.7
+tqdm==4.62.3
+unidiff==0.7.0


### PR DESCRIPTION
Installing without freezing package versions leads to compatibility issues between (the latest versions of) the required packages. The version numbers proposed here were arrived at through trial and error, by iteratively or raising lowering version numbers when required, and may not represent the most up-to-date compatible versions for all packages. The proposed configuration successfully installs PLUR following the steps in the README in a clean Python:3.9 Docker container.