### PR TITLE
Update requirements to fix Py3.8 build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,23 @@
 # List of dependencies to install
-absl-py>=0.12.0
-apache-beam>=2.34.0
+absl-py==1.0.0
+apache-beam==2.37.0
 GitPython>=3.1.24  # for "git" module
-google-cloud-storage>=1.43.0
+google-cloud-storage>=2.1.0
 immutabledict>=2.2.1
 javalang>=0.13.0
 jax>=0.2.26
-jaxlib>=0.1.76
 flax>=0.3.6
 trax>=1.4.1
-numpy>=1.19.5
+numpy==1.21.5
+pyparsing==2.4.7
 scipy>=1.6.1
 requests>=2.24.0
 tensorflow>=2.5.0
 tqdm>=4.62.3
 tensor2tensor>=1.15.7
 unidiff>=0.7.0
+kfac==0.2.0
 nltk>=3.6.6
+dopamine-rl==3.2.1
+-f https://storage.googleapis.com/jax-releases/jax_releases.html
+jaxlib==0.3.0+cuda11.cudnn82


### PR DESCRIPTION
The previous version constraints only successfully built PLUR in a Python 3.9 environment. The below refines some of these versions to work with Python 3.8, and in particular, to be compatible with a Tensorflow 2.8.0-GPU Docker image, which ships with that version of Python by default. I expect that these changes will fix setup bugs in other environments too, and plan to push the corresponding docker image and/or Dockerfile soon to simplify the setup process.

This mostly required freezing a higher version of a few packages to avoid conflicts and adding a few new explicit version requirements. Some of the new version constraints are probably too rigid and can be converted into `>=`; feel free to edit if so. The Jaxlib import is to ensure that a Cuda-compatible version is used, which does not happen by default. That might be too specific for this repository, so feel free to ignore that change.